### PR TITLE
Feature: Use GitHub Actions to deploy on vercel instead of the fork way

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release Deployment
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Deploy
+        uses: amondnet/vercel-action@v19
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-args: '--prod'
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./


### PR DESCRIPTION
# Story Title

[Feature: Use GitHub Actions to deploy on vercel instead of the fork way](https://github.com/kuru-studio/kuru-studio-social-web/issues/9)

## Changes made

- Add release.yml

## How does the solution address the problem

This PR will move the deploying of the repository to Vercel from BosEriko's fork to a GitHub action here inside this repository. Please check [this](https://github.com/thimble-bot/web/blob/master/.github/workflows/release.yml) out and be sure to create a skip-ci function. Check out your [Notion](https://www.notion.so/kuru-studio/Use-GitHub-Actions-to-deploy-on-vercel-instead-of-the-fork-way-a05803aebaba454392c4aaa850a2375d) for information on how to do the skip-ci.

## Linked issues

Resolves #9
